### PR TITLE
Fix ICE in `peekable` with unsized types

### DIFF
--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1029,6 +1029,7 @@ pub trait Iterator {
     fn peekable(self) -> Peekable<Self>
     where
         Self: Sized,
+        Self::Item: Sized,
     {
         Peekable::new(self)
     }

--- a/tests/ui/iterators/unsized-peekable.rs
+++ b/tests/ui/iterators/unsized-peekable.rs
@@ -1,0 +1,11 @@
+//@ compile-flags: -Zmir-enable-passes=+Inline -Zmir-enable-passes=+JumpThreading --crate-type=lib
+
+pub fn problem_thingy(items: &mut impl Iterator<Item = str>) {
+    let mut peeker = items.peekable();
+    //~^ ERROR: the size for values of type `str` cannot be known at compilation time [E0277]
+    // ^^^ doesn't have a size known at compile-time
+    match peeker.peek() {
+        Some(_) => (),
+        None => return (),
+    }
+}

--- a/tests/ui/iterators/unsized-peekable.stderr
+++ b/tests/ui/iterators/unsized-peekable.stderr
@@ -1,0 +1,13 @@
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/unsized-peekable.rs:4:28
+   |
+LL |     let mut peeker = items.peekable();
+   |                            ^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+note: required by a bound in `peekable`
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
This commit resolves an Internal Compiler Error (ICE) caused by calling `peekable` on iterators with unsized item types. The issue arises due to MIR optimizations (`Inline` and `JumpThreading`) encountering invalid states when handling unsized types.

Changes:
  - Added a `Self::Item: Sized` bound to the `peekable` method in `Iterator` trait to prevent usage with unsized types.
  - Introduced a new test case (`tests/ui/iterators/unsized-peekable.rs`) to verify that attempting to use `peekable` with unsized types results in a proper compile-time error instead of an ICE.

This fix ensures that the compiler provides a clear and actionable error message (`E0277`) when `peekable` is used with unsized types, avoiding invalid intermediate representations during MIR optimization.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
